### PR TITLE
adding WQL features

### DIFF
--- a/delphin/wql/_NodeExpression.py
+++ b/delphin/wql/_NodeExpression.py
@@ -1,5 +1,3 @@
-PREDICATE = "predicate"
-
 BRACKETS_BGN = "["
 BRACKETS_END = "]"
 IDENTIFIER_OUT = "[{^"
@@ -20,12 +18,12 @@ class NodeExpression():
         self.id = self._trim_id(expression)
         self.roles = self._trim_roles(expression) 
 
-        # Processes the expression between ID and ROLES
-        expression = re.sub(".*:", "", expression)
-        expression = re.sub("\[.*\]", "", expression)
-        self.body = None if len(expression) == 0 else expression
-        
-        self.values = {PREDICATE:self.body}
+        # consumes the rest of expression
+        self.values = dict()
+
+        expression = re.sub(r".*:", "", expression)
+        expression = re.sub(r"\[.*\]", "", expression)
+        self._consume_text(expression.strip())
 
     def _trim_id(self,expression):
         """Separates expresion ID if given"""
@@ -41,6 +39,22 @@ class NodeExpression():
                 raise Exception(f"Check identifiers in {expression}")
 
         return identifier
+
+    def _consume_text(self, expression):
+        """"""
+        # * what about patterns in consumeText
+        # * define patterns as future feature
+
+        if len(expression) == 0: return
+
+        # a container of patterns in expression
+        found = None
+
+        # {...} define patterns feature
+
+        if len(expression) > 0: 
+            if found == None:
+                self.values["predicate"] = expression.strip()
 
     def _trim_roles(self,expression):
         """Separates the roles from expression"""

--- a/delphin/wql/_NodeExpression.py
+++ b/delphin/wql/_NodeExpression.py
@@ -1,0 +1,74 @@
+PREDICATE = "predicate"
+
+BRACKETS_BGN = "["
+BRACKETS_END = "]"
+IDENTIFIER_OUT = "[{^"
+IDENTIFIER_CHAR = ":"
+
+import re
+
+class NodeExpression():
+    def __init__(self,expression):
+        """"""
+        # * add the QUOTE notation
+        # * use Regular Expressions
+        # * add _consume_text method?
+        # * consider the ALL PATTERNS
+
+        self.expression = expression
+        
+        self.id = self._trim_id(expression)
+        self.roles = self._trim_roles(expression) 
+
+        # Processes the expression between ID and ROLES
+        expression = re.sub(".*:", "", expression)
+        expression = re.sub("\[.*\]", "", expression)
+        self.body = None if len(expression) == 0 else expression
+        
+        self.values = {PREDICATE:self.body}
+
+    def _trim_id(self,expression):
+        """Separates expresion ID if given"""
+        # finds identifier
+        identifier_end = expression.find(IDENTIFIER_CHAR)
+        if identifier_end == -1:
+            return None
+        identifier = expression[:identifier_end]
+
+        # validates identifier
+        for char in IDENTIFIER_OUT:
+            if char in identifier:
+                raise Exception(f"Check identifiers in {expression}")
+
+        return identifier
+
+    def _trim_roles(self,expression):
+        """Separates the roles from expression"""
+        # * add the QUOTE notation
+        # * why using a CLASS for ROLE?
+        # * add expception for ROLE
+        # * use Regular Expressions
+
+        # if there are no ROLES
+        if len(expression) <= 3 or not expression.endswith(BRACKETS_END):
+            return None
+        
+        # search for ROLES
+        end = expression.rfind(BRACKETS_END)
+        bgn = expression.rfind(BRACKETS_BGN)
+
+        if bgn == -1:
+            raise Exception(f"Invalid expression {expression}")
+
+        roles = expression[bgn+1:end]
+        roles_ = []
+        for role in roles.split(","):
+            splitted = role.strip().split(" ")
+            if not len(splitted) == 2:
+                raise Exception(f"Check ROLES in {expression}")
+            roles_.append(splitted)
+        
+        return roles_
+
+    def is_leaf(self): return True
+    def is_compact(self): return True

--- a/delphin/wql/_NotExpression.py
+++ b/delphin/wql/_NotExpression.py
@@ -1,0 +1,3 @@
+class NodeExpression():
+    def __init__(self,expression):
+        self.expression = expression

--- a/delphin/wql/_NotExpression.py
+++ b/delphin/wql/_NotExpression.py
@@ -1,3 +1,0 @@
-class NodeExpression():
-    def __init__(self,expression):
-        self.expression = expression

--- a/delphin/wql/_OperationExpression.py
+++ b/delphin/wql/_OperationExpression.py
@@ -1,0 +1,16 @@
+
+OPERATOR_AND = OPERATOR_CON = "&"
+OPERATOR_NOT = OPERATOR_NEG = "!"
+OPERATOR_ORR = OPERATOR_DIS = "|"
+OPERATOR_ALL = OPERATOR_ANY = OPERATOR_CON+OPERATOR_DIS+OPERATOR_NEG
+
+class OperationExpression():
+    def __init__(self,operation,left,right=None):
+        self.left = left
+        self.operator = operation
+        self.right = left if right == None else right
+
+        self.compact = False
+    
+    def is_leaf(self): return False
+    def is_compact(self): return self.compact

--- a/delphin/wql/_QEQExpression.py
+++ b/delphin/wql/_QEQExpression.py
@@ -1,0 +1,20 @@
+
+QEQ_BGN = "{"
+QEQ_END = "}"
+
+class QEQExpression:
+    def __init__(self,expression):
+        self.expression = expression
+        
+        # separates constraints
+        self.qeqs = expression.replace(" ","").split(",")
+        self.qeqs = [qeq.split("=q") for qeq in self.qeqs]
+        # validates the splitting
+        for qeq in self.qeqs:
+            if not len(qeq) == 2:
+                raise Exception(f"Invalid constraint in {expression}")
+
+
+
+    def is_leaf(self): return True
+    def is_compact(self): return True

--- a/delphin/wql/_TempData.py
+++ b/delphin/wql/_TempData.py
@@ -1,0 +1,12 @@
+class TempData:
+    def __init__(self):
+        """"""
+        self.count = 99
+        self.variables = []
+    
+    def new_variable(self):
+        """"""
+        self.count = self.count + 1
+        variable = f"aux{self.count}"
+
+        return variable

--- a/delphin/wql/_to_sparql.py
+++ b/delphin/wql/_to_sparql.py
@@ -1,0 +1,218 @@
+from _NodeExpression import PREDICATE
+from _NodeExpression import NodeExpression
+from _QEQExpression import QEQExpression
+
+from _OperationExpression import OPERATOR_CON as CONOP
+from _OperationExpression import OPERATOR_DIS as DISOP
+from _OperationExpression import OPERATOR_NEG as NEGOP
+
+NEQLEVEL = 20
+QEQLEVEL = 6
+
+prefixes = (
+    '@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .',
+    '@prefix delph: <http://www.delph-in.net/schema/> .',
+    '@prefix erg: <http://www.delph-in.net/schema/erg#> .',
+    '@prefix mrs: <http://www.delph-in.net/schema/mrs#> .',
+    '@prefix pos: <http://www.delph-in.net/schema/pos#> .',
+    '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .', '\n')
+
+def _to_sparql_structure(expression, ordered = False):
+    """
+    - initialize(output) : prefixos
+    - toSparql(parsed, aux) : recusivo; operacao ou folha
+        - toSparqlOperator()
+        - toSparqlNode()
+    - adicionamos sufixos, ordenacao, variaveis, etc
+    """
+    # * qual a utilizade/significado de aux/temp
+    # * qual a substituto para "SELECT GRAPH"
+    # * completar e entender _to_sparql_body
+    # * maneira de atualizar/ajustar a query
+    # * entender melhor o sparql gerado
+    # * adicionar a feature de ordenamento
+    # * adicionar unique_filter feature
+
+    # initialize output with prefixes
+    sparql = "\n".join(prefixes)
+
+    # generate structures sparql and
+    # converts it to a string sparql
+    auxiliar_variables = []         # a container for generated variables
+    auxiliar_variables += ["aux0", "aux1", "aux2", "aux3", "aux4", "aux5"]
+    sparql_where = _to_sparql(expression,auxiliar_variables).to_sparql_string()
+
+    # add other elements
+    sparql += "SELECT \n\t?GRAPH "
+    for var in auxiliar_variables:
+        sparql += f"?{var} "
+    sparql += "\nWHERE\n\t{" + sparql_where+" }"
+
+    # add_unique_filter
+
+    return sparql
+
+def _to_sparql(expression, temp):
+    """
+    Modela a query-tree como uma Weighted String,
+    o que é feito recursivamente.
+    """
+    if expression.is_leaf():
+        return _to_sparql_node(expression, temp)
+    return _to_sparql_operator(expression, temp)
+
+def _to_sparql_node(expression, temp):
+    """"""
+    
+    # * needs a complete definition
+    # * define a general parser based on
+    # classes: MRS.to_sparql(temp)
+
+    # if a QEQExpresion
+    if type(expression) == QEQExpression:
+        return _to_sparql_qeqs(expression,temp)
+
+    # if a NodeExpression
+    if type(expression) == NodeExpression:
+        return _to_sparql_body(expression,temp)
+    
+    return WeightedString(0,0,None)
+
+def _to_sparql_qeqs(expression,temp):
+    """"""
+    # * use vocalbularie definition of QEQ relations
+
+    qeqs = expression.qeqs
+    output = ["?{} mrs:Qeq ?{} .".format(*qeq) for qeq in qeqs]
+    output = "\n".join(output)
+
+    return WeightedString(QEQLEVEL, 0, output)
+
+def _to_sparql_body(expression,temp):
+    """"""
+    # * need to understand almost everything
+    # * review vocabularie
+
+    return WeightedString(QEQLEVEL, 0, expression.expression)
+
+def _level(name):
+    """"""
+    pass
+
+def _add_data_value(id,level,value,type):
+    """"""
+    pass
+
+def _to_sparql_operator(expression, temp):
+    """"""
+    # * meaning of a Weighted String
+    # * code reuse on OROP
+    # * code reuse for lambda x: (x.level,x.weight)
+
+    # NEGOP tranforms and add FILTER
+    if expression.operator == NEGOP:
+        w_child = _to_sparql(expression.left, temp)
+        output = f"FILTER NOT EXISTS { {w_child.to_sparql_string()} }"
+
+        return WeightedString(NEQLEVEL,0,output)
+    
+    # otherwise parses both sides
+    left = _to_sparql(expression.left,temp)
+    right = _to_sparql(expression.right,temp)
+
+    # DISOP
+    if expression.operator == DISOP:
+        if left.value == None:
+            # sorts by level than weight
+            left.values = sorted(left.values, left._compare_key)
+            left.value = left.to_sparql_string()
+            # sets largest level from values
+            left.level = left.values[-1].level
+        
+        if right.value == None:
+            # sorts by level than weight
+            right.values = sorted(right.values, key=right._compare_key)
+            right.value = right.to_sparql_string()
+            # sets largest level from values
+            right.level = right.values[-1].level
+        
+        _expression = sorted([left,right], key=right._compare_key)
+        return WeightedString(
+            left._level(_expression),
+            left.weight + right.weight,
+            left._to_union_string(_expression))
+
+    # CONOP considers the agregation
+    _expression = []
+
+    if left.value == None: _expression += left.values
+    else: _expression.append(left)
+    if right.value == None: _expression += right.values
+    else: _expression.append(right)
+
+    return WeightedString(values=_expression)
+    
+class WeightedString:
+    def __init__(self,level=None,weight=None,value=None,values=None):
+        """
+        A Weighted String contains an expression
+        os a sequence of Weighted Strings, wich,
+        in this second case, define the weight
+        """
+
+        self.level = level
+        self.value = value
+        self.weight = weight
+        self.values = values
+        # two ways to describe a WS
+        if not values == None:
+            self.weight = self._weight(values)
+    
+    def _compare_key(self,x): return (x.level,x.weight)
+
+    def _weight(self,values):
+        """
+        A Weighted String's weight is given as a
+        reunion of it's values/items' weights
+        """
+        weight = 0
+        for value in values:
+            if not value.values == None:
+                weight += self._weight(value.values)
+            else: weight += value.weight
+        return weight
+    
+    def _level(self, values):
+        """
+        Search the least level, where the level
+        is given by it's values
+        """
+        # * De onde vem, o que significa 110?
+
+        level = 110
+        for value in values:
+            l = value.level
+            if l == 0: l = self._level(value)
+            if l < level: level = l
+        return level
+
+    def _to_union_string(self,values):
+        first = values[0]
+        if len(values) == 1: return first.to_sparql_string()
+
+        return f"{ {first.to_sparql_string()} } UNION { {self._to_union_string(values[1:])} }"
+    
+    def to_sparql_string(self):
+        """
+        Converte a Weighted String, na forma sparql
+        representada. Para isso considera aspectos
+        como peso, nivel valor e valores.
+        """
+        # * better readability by newlines
+        
+        # if a node/leaf return the value
+        if not self.value == None: return self.value
+        
+        # othewise, sorts and calls recursively
+        self.values = sorted(self.values, key=self._compare_key)
+        return " ".join([ws.to_sparql_string() for ws in self.values])

--- a/delphin/wql/_to_tree.py
+++ b/delphin/wql/_to_tree.py
@@ -1,0 +1,208 @@
+import re
+
+from _QEQExpression import QEQExpression
+from _QEQExpression import QEQ_BGN
+from _QEQExpression import QEQ_END
+
+from _NodeExpression import NodeExpression
+
+from _OperationExpression import OperationExpression
+from _OperationExpression import OPERATOR_ANY as ANYOP
+from _OperationExpression import OPERATOR_CON as CONOP
+from _OperationExpression import OPERATOR_DIS as DISOP
+from _OperationExpression import OPERATOR_NEG as NEGOP
+
+def tree_to_str(expression, n=0):
+    output = _tree_to_str(expression, n).rstrip()
+    # prefix = "-------------------------------------------------"
+    # prefix = "##################################################"
+    prefix = ""
+
+    return "\n".join([prefix,output,prefix])
+
+def _tree_to_str(expression, n=0, prefix=None):
+    output = ""
+    prefix = "\t"*n if prefix==None else prefix
+    try:
+        # expression is a NEGATION
+        if expression.operator == NEGOP:
+            output += _tree_to_str(expression.right,n+1,"\r"+prefix+expression.operator+"\t")
+        # expression is a CON / DIS
+        elif expression.operator in ANYOP:
+            output += _tree_to_str(expression.left,n+1)
+            output += prefix + expression.operator + "\n"
+            output += _tree_to_str(expression.right,n+1)
+    except Exception:
+        # expression is a NODE/LEAF
+        output += prefix + expression.expression + "\n"
+    return output
+
+def _parse(query:str):
+    """"""
+    
+    # strip blank spaces
+    query.strip()
+    
+    # parses QEQs separately if given
+    bgn = None
+    end = None
+    qeqs_member = None
+    if query.endswith(QEQ_END):
+        bgn = query.rfind(QEQ_BGN)
+        end = query.rfind(QEQ_END)
+        qeqs_member = query[bgn+1:end]
+    
+    # parses BODY separately if given
+    body_member = query[0:bgn].strip()
+    body_member = _format(body_member)
+    body_member = _recognize(body_member)
+
+    if qeqs_member == None:
+        return body_member
+
+    # conjunction of both expressions
+    qeqs_member = QEQExpression(qeqs_member)
+
+    out_expression=OperationExpression(CONOP, body_member, qeqs_member)
+    return out_expression
+
+def _format(query:str):
+    # * what about quote "\\\\" replacement
+    # * possible use Regular Expressions instead
+    # * in the original code the supress operator "\" is not implemented
+    # * question about the used definition of in/out
+    # * definition of problems opening and closing brackets
+
+    # replace repeated unecessary whitespaces
+    query = re.sub(r'\s+', ' ', query)
+    query = re.sub(r'(?<=[\[\{|&,!]) ', '', query)
+    query = re.sub(r' (?=[\]\}|&,!])', '', query)
+    query = re.sub(r'\\\\', '\\\\', query)
+    query = query.lstrip()
+    
+    # format operations to standard
+    query = re.sub(r'\&', CONOP, query)
+    query = re.sub(r'\|', DISOP, query)
+    query = re.sub(r'\!', NEGOP, query)
+
+    # searchs for problems with the brackets
+    if re.search(r'(\[[^\].]*\{[^\}.]*\]|\{[^\}.]*\[[^\].]*\})', query):
+        raise Exception("Check opening and closing the brackets!")
+    # replace spaces outside brackets
+    query = re.sub(r'\s(?!([^(\[|\{).]*(\]|\})))', '&', query)
+    query = re.sub(r'\s(?!([^(\]|\}).]*(\[|\{)))', '&', query[-1::-1])[-1::-1]
+
+    return query
+
+def _push_nots(expression):
+    """"""
+    
+    # a "pure expression" or leaf
+    if expression.is_leaf():
+        return expression
+    # a CONJ / DISJ expression
+    if not expression.operator == NEGOP:
+        _push_nots(expression.left)
+        _push_nots(expression.right)
+        return expression
+    # a NOT introducing a leaf 
+    if expression.left.is_leaf():
+        return expression
+    
+    # a NOT introduces a subtree
+    # in this case apply Third Excluded
+    child = expression.left
+    if child.operator == NEGOP:
+        return child.left
+    
+    # in this case apply DeMorgan mapping
+    expression.operator = {CONOP:DISOP,DISOP:CONOP}[child.operator]
+    expression.left  = _push_nots(OperationExpression(NEGOP, child.left))
+    expression.right = _push_nots(OperationExpression(NEGOP, child.right))
+
+    return expression
+    
+def _recognize(query:str):
+    """
+    extruturamos a arvore, operacoes, roles e IDs
+    """
+    # * definition, meaning and usability of "compact"
+    # * care about the Operators Precedence
+
+    operator = None
+    operator_index = None
+    # a negation of an expression
+    if query.startswith(NEGOP):
+        expression = _recognize(query[1:])
+        
+        # if negation precedes a compact
+        if _precedence_neg(expression):
+            return OperationExpression(NEGOP, expression)
+        
+        # searchs first left compact
+        parent = expression
+        child  = parent.left
+        while not _precedence_neg(child):
+            parent = child
+            child = parent.left
+        parent.left = OperationExpression(NEGOP, child)
+
+        return expression
+
+    # expression inside parenthesis
+    if query.startswith("("):
+        # problem if parenthesis not closed
+        closed_parenthesis_index = query.rfind(")")
+        if closed_parenthesis_index == -1:
+            raise Exception(f"Check parenthesis in {query}")
+
+        # if query simply enclosed by parenthesis
+        query_last_index = len(query)-1
+        if closed_parenthesis_index == query_last_index:
+            expression = _recognize(query[1:closed_parenthesis_index])
+            expression.compact = True
+            return expression
+        
+        # defines the operator position
+        operator_index = closed_parenthesis_index+1
+        operator = query[operator_index]
+        left  = _recognize(query[:operator_index])
+        right = _recognize(query[operator_index+1:])
+        left.compact = True
+
+        return OperationExpression(operator,left,right)
+    
+    # if not parethesis, finds operators
+    operator_index = _find_operator(query, CONOP+DISOP)
+
+    # if not operator, a simple node
+    if operator_index == -1:
+        return NodeExpression(query)
+    
+    # both sides if operator
+    operator = query[operator_index]
+    left  = _recognize(query[:operator_index])
+    right = _recognize(query[operator_index+1:])
+    
+    if operator == DISOP or _precedence_con(right):
+        return OperationExpression(operator,left,right)
+    parent = right
+    child  = parent.left
+    while not _precedence_con(child):
+        parent = child
+        child  = parent.left
+    parent.left = OperationExpression(operator, child)
+
+    return OperationExpression(operator,left,right)
+
+def _precedence_neg(expression):
+    return expression.is_compact() or expression.operator == NEGOP 
+
+def _precedence_con(expression):
+    return _precedence_neg(expression) or expression.operator == CONOP
+
+
+def _find_operator(query, operators):
+    if len(query) == 0 or len(operators) == 0: return -1
+    indexes = [query.find(o) for o in operators if o in query]
+    return -1 if len(indexes) == 0 else min(indexes)

--- a/delphin/wql/wql.py
+++ b/delphin/wql/wql.py
@@ -37,7 +37,7 @@ def generate_sparql(query:str):
         query : a WQL formated query to be parsed
     
     Output:
-        a string containing MRS  SPARQL query
+        a string containing the MRS SPARQL query
     """
 
     # format query and evaluate query tree

--- a/delphin/wql/wql.py
+++ b/delphin/wql/wql.py
@@ -1,0 +1,96 @@
+"""
+WeSearch Query Language (WQL) into Sparql for RDF queries.
+
+: (colon), separates optional node identifier from node content;
+[ (left square bracket), separates node properties from outgoing arcs;
+] (right square bracket), terminates a list of outgoing arcs;
+  (whitespace), separates role labels and values in list of arcs;
+, (comma), separates role–value pairs within list of outgoing arcs;
++ (plus sign), indicates (optional) lemma object property;
+/ (slash), indicates (optional) pos property;
+? (question mark), Lucene-style single-character wildcard;
+* (asterisk), Lucene-style arbitrary sub-string wildcard;
+| (vertical bar), logical disjunction (see below);
+( and ) (left and right parentheses), grouping of sub-expressions (see below);
+! (exclamation mark), reserved for negation (to be defined);
+\ (backslash), escape character, suppressing operator status for all of the above.
+
+see: http://moin.delph-in.net/WeSearch/QueryLanguage
+"""
+
+import argparse
+import logging
+logger = logging.getLogger("wql")
+
+from _to_tree import _parse
+from _to_tree import _push_nots
+from _to_tree import tree_to_str
+
+from _to_sparql import _to_sparql_structure
+
+def generate_sparql(query:str):
+    """
+    Parses a WQL query into SPARQL language using a MRS
+    based output format at first.
+    
+    Args:
+        query : a WQL formated query to be parsed
+    
+    Output:
+        a string containing MRS  SPARQL query
+    """
+
+    # format query and evaluate query tree
+    logger.info(f"parsing query: {query}")
+    query = _parse(query)
+    logger.debug(f"parsed query tree: \n{tree_to_str(query)}")
+    query = _push_nots(query)
+    logger.debug(f"optmized query tree: \n{tree_to_str(query)}")
+
+
+    # parse to sparql structure than string
+    logger.info(f"parsing query tree into sparql...")
+    sparql = _to_sparql_structure(query)
+
+    print(sparql)
+
+
+
+# ProcessingDefaults
+# - sparql = exp.generateSparql(query)
+#   - query = query.parse(query)
+#     - separamos e parseamos o QEQ
+#     - separamos e parseamos o corpo
+#       - query = format(query) : espaços, ajustamos operacoes, consideramos caracteres e localizacao
+#       - query = recognize(query) : extruturamos arvore, (compacto: processado?), nós (nao operados), operacoes, roles, IDs, validacao
+#         - searchOperator()
+#         - parseNodes()
+#       - pushNot(query) : demorgan simplificando a expressao
+#  - sparql = toSparqlStructure(query)
+#    - initialize(output) : prefixos
+#    - toSparql(parsed, aux) : recusivo; operacao ou folha
+#      - toSparqlOperator()
+#      - toSparqlNode()
+#    - adicionamos sufixos, ordenacao, variaveis, etc
+
+# define Command Line Interface arguments
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument(
+    dest="sentence",
+    help="expression to be parsed",
+    default="[* x]{h1 =q h3, h1 =q h2}")
+parser.add_argument(
+    '-v', '--verbose',
+    action='count',
+    dest='verbosity',
+    default=0)
+
+args = parser.parse_args()
+
+# define Command Line Interface verbosity
+base_loglevel = 30
+verbosity = min(args.verbosity, 2)
+loglevel = base_loglevel - (args.verbosity * 10)
+logging.basicConfig(level=loglevel)
+
+generate_sparql(args.sentence)


### PR DESCRIPTION
Hi. I spent some time this week re-implementing some features from _WQL to mrs-sparql_ from WSI, aiming to better understand the meaning of some pieces code, and as a beginning for our purpose of implementing this query generator.

For now, we have two main processes that (1 - in `_to_tree`) expresses the query as an optimized tree whose leaves are atomic expressions, and (2 - in `_to_sparql`) parses the tree into sparql, adding auxiliary variables, types and other features. The second process isn't completely implemented yet.

One may be able to run the code, for instance, as

```
$ python path/to/wql.py -vvv "!([ARG2 x, ARG3 h1] | ! h2:*_v_*[ARG0 e, ARG1 x]) { h1 =q h2, h2 =q h3}"
```

There are some modifications and comments made from the original code that could be discussed further, such as: using regular expressions, pushing some methods to classes, trying some code reuse, etc.