### PR TITLE
Sortinfo

### DIFF
--- a/delphin/cli/profile_to_rdf.py
+++ b/delphin/cli/profile_to_rdf.py
@@ -58,11 +58,15 @@ def __cli_parse__(args):
         
         # open Test Suite and start conversion
         ts = itsdb.TestSuite(path)
-        logger.info(f"Converting {len(ts['result'])} analysis of {len(ts['item'])} sentences from {args.profile}")
-        
+        # logger.info(f"Converting {len(ts['result'])} analysis of {len(ts['item'])} sentences from {args.profile}")
+        logger.log(30,f"Converting {len(ts['result'])} analysis of {len(ts['item'])} sentences from {args.profile}")
+
         # The tsql takes some time to be processed:
-        logger.info(f"Loading the profile")
-        for (parse_id, result_id, text, mrs_string) in tsql.select('parse-id result-id i-input mrs', ts):
+        # logger.info(f"Loading the profile")
+        logger.log(30,f"Loading the profile")
+        profile_data = tsql.select('parse-id result-id i-input mrs', ts)
+        logger.log(30,f"Converting the profile")
+        for (parse_id, result_id, text, mrs_string) in profile_data:
             logger.info(f"Converting the result {result_id} of sentence {parse_id}")
             m = simplemrs.decode(mrs_string)
 
@@ -83,9 +87,9 @@ def __cli_parse__(args):
                         text=text)
 
         # serializes results
-        logger.info(f"Serializing results to {args.output}")
+        logger.log(30,f"Serializing results to {args.output}")
         graph.serialize(destination=args.output, format=args.format)
-        logger.info(f"DONE")
+        logger.log(30,f"DONE")
 
     # except PyDelphinSyntaxError as e:
     #     logger.exception(e)

--- a/delphin/rdf/_dmrs_parser.py
+++ b/delphin/rdf/_dmrs_parser.py
@@ -31,6 +31,7 @@ def __nodes_to_rdf__(d, graph, dmrsi, NODES):
         node = d.nodes[i]
         nodeIRI = NODES["{}".format(node.id)] #era i, mas não da pra fazer link assim. Rever.
         nodePredIRI = nodeIRI + "-predicate"
+        nodeSortInfoIRI = nodeIRI + "-sortinfo"
         
         #putting it's id 
         graph.add((nodeIRI, DMRS.hasId, Literal(node.id)))
@@ -68,8 +69,10 @@ def __nodes_to_rdf__(d, graph, dmrsi, NODES):
             graph.add((nodeIRI, DELPH.cto, Literal(node.cto)))
 
         #properties / sortinfo
+        graph.add((nodeIRI, DELPH.hasSortInfo, nodeSortInfoIRI))
+        graph.add((nodeSortInfoIRI, RDF.type, DELPH.SortInfo))
         for prop, val in node.properties.items():
-            graph.add((nodeIRI, ERG[prop.lower()], Literal(val.lower())))
+            graph.add((nodeSortInfoIRI, ERG[prop.lower()], Literal(val.lower())))
         
         #type:
         if node.type is not None:
@@ -78,7 +81,7 @@ def __nodes_to_rdf__(d, graph, dmrsi, NODES):
             
         # carg
         if node.carg is not None:
-            graph.add((nodeIRI, DELPH.carg, Literal(node.carg)))
+            graph.add((nodeSortInfoIRI, DELPH.carg, Literal(node.carg)))
 
 
 def __links_to_rdf__(d, graph, dmrsi, NODES, LINKS):

--- a/delphin/rdf/_dmrs_parser.py
+++ b/delphin/rdf/_dmrs_parser.py
@@ -14,7 +14,7 @@ ERG = Namespace("http://www.delph-in.net/schema/erg#")
 DELPH = Namespace("http://www.delph-in.net/schema/")
 POS = Namespace("http://www.delph-in.net/schema/pos#")
 
-def __nodes_to_rdf__(d, graph, dmrsi, NODES):
+def __nodes_to_rdf__(d, graph, dmrsi, NODES, namespace):
     """
     Creates nodes of variables and nodes specifying their properties.
 
@@ -26,12 +26,14 @@ def __nodes_to_rdf__(d, graph, dmrsi, NODES):
     representation.
 
     NODES - the URI namespace dedicated to nodes.
+
+    namespace - the string namespace of a result of the profile.
     """
     for i in range(len(d.nodes)):
         node = d.nodes[i]
         nodeIRI = NODES["{}".format(node.id)] #era i, mas não da pra fazer link assim. Rever.
-        nodePredIRI = nodeIRI + "-predicate"
-        nodeSortInfoIRI = nodeIRI + "-sortinfo"
+        nodePredIRI = URIRef(f"{namespace}predicate-{node.id}")
+        nodeSortInfoIRI = URIRef(f"{namespace}sortinfo-{node.id}")
         
         #putting it's id 
         graph.add((nodeIRI, DMRS.hasId, Literal(node.id)))
@@ -166,7 +168,7 @@ def dmrs_to_rdf(d, prefix: str, identifier, iname="dmrs", graph=None, out=None, 
     graph.bind("pos", POS)
     
     #Creating RDF triples
-    __nodes_to_rdf__(d, graph, dmrsi, NODES)
+    __nodes_to_rdf__(d, graph, dmrsi, NODES, namespace)
     #Adding top
     graph.add((dmrsi, DMRS['hasTop'], NODES["{}".format(d.top)]))
     #Adding index

--- a/delphin/rdf/_dmrs_parser.py
+++ b/delphin/rdf/_dmrs_parser.py
@@ -30,11 +30,11 @@ def __nodes_to_rdf__(d, graph, dmrsi, NODES):
     for i in range(len(d.nodes)):
         node = d.nodes[i]
         nodeIRI = NODES["{}".format(node.id)] #era i, mas não da pra fazer link assim. Rever.
-        nodePredIRI = nodeIRI + "#predicate"
+        nodePredIRI = nodeIRI + "-predicate"
         
         #putting it's id 
         graph.add((nodeIRI, DMRS.hasId, Literal(node.id)))
-        graph.add((nodeIRI, RDFS.label, Literal("{}<{},{}>".format(node.predicate,node.cfrom,node.cto))))
+        graph.add((nodeIRI, RDFS.label, Literal(f"{node.predicate}<{node.cfrom},{node.cto}>")))
         
         #Instantiate the Node and putting into the DMRS
         graph.add((nodeIRI, RDF.type, DMRS.Node))
@@ -61,7 +61,7 @@ def __nodes_to_rdf__(d, graph, dmrsi, NODES):
         graph.add((nodeIRI, DELPH.hasPredicate, nodePredIRI))
         graph.add((nodePredIRI, DELPH.predText, Literal(delphin.predicate.normalize(node.predicate))))
         
-        # links
+        # lnk
         if node.cfrom is not None:
             graph.add((nodeIRI, DELPH.cfrom, Literal(node.cfrom)))
         if node.cto is not None:
@@ -107,8 +107,8 @@ def __links_to_rdf__(d, graph, dmrsi, NODES, LINKS):
         graph.add((dmrsi, DMRS.hasLink, linkIRI))
         
         # the directions
-        graph.add((linkIRI, DMRS.hasFrom, NODES["{}".format(link.start)]))
-        graph.add((linkIRI, DMRS.hasTo, NODES["{}".format(link.end)]))
+        graph.add((linkIRI, DMRS.hasFrom, NODES[f"{link.start}"]))
+        graph.add((linkIRI, DMRS.hasTo, NODES[f"{link.end}"]))
         
         # adding roles and posts and creating (just to make sure, maybe remove the last one)
         graph.add((linkIRI, DMRS.hasRole, DMRS[link.role.lower()]))
@@ -117,7 +117,7 @@ def __links_to_rdf__(d, graph, dmrsi, NODES, LINKS):
         graph.add((DMRS[link.role.lower()], RDF.type, DMRS.Role)) 
 
 
-def dmrs_to_rdf(d, prefix: str, identifier, iname="dmrsi#dmrs", graph=None, out=None, text=None, format="turtle"):
+def dmrs_to_rdf(d, prefix: str, identifier, iname="dmrs", graph=None, out=None, text=None, format="turtle"):
     """
     Parses a pydelphin DMRS into RDF representation.
 
@@ -132,7 +132,7 @@ def dmrs_to_rdf(d, prefix: str, identifier, iname="dmrsi#dmrs", graph=None, out=
     same text admits various mrs interpretations.
 
     iname - the dmrs instance name (the dmrs as RDF node name)
-    to be used. As default, it is "dmrsi#dmrs".
+    to be used. As default, it is "dmrs".
 
     graph - and rdflib graph. If given, uses it to store the
     dmrs as RDF representation.
@@ -148,13 +148,13 @@ def dmrs_to_rdf(d, prefix: str, identifier, iname="dmrsi#dmrs", graph=None, out=
     if type(identifier) == list:
         identifier = "/".join(identifier)
 
-    namespace = prefix + "/" + identifier + "/"
+    namespace = prefix + "/" + identifier + "#"
 
     #creating the instance URI and the namespaces
     dmrsi = URIRef(namespace + iname)
     graph.add((dmrsi, RDF.type, DMRS.DMRS))
-    NODES = Namespace(namespace + "nodes/")
-    LINKS = Namespace(namespace + "links/")
+    NODES = Namespace(namespace + "node-")
+    LINKS = Namespace(namespace + "link-")
     
     #creating the prefixes of the output
     graph.bind("dmrs", DMRS)

--- a/delphin/rdf/_dmrs_parser.py
+++ b/delphin/rdf/_dmrs_parser.py
@@ -48,7 +48,7 @@ def __nodes_to_rdf__(d, graph, dmrsi, NODES):
         elif delphin.predicate.is_abstract(node.predicate):
             graph.add((nodePredIRI, RDF.type, DELPH.AbstractPredicate))
         else:
-            graph.add((nodePredIRI, RDF.type, DMRS.Predicate))
+            graph.add((nodePredIRI, RDF.type, DELPH.Predicate))
             print("An invalid predicate")
 
         if splittedPredicate[0] is not None:

--- a/delphin/rdf/_eds_parser.py
+++ b/delphin/rdf/_eds_parser.py
@@ -14,7 +14,7 @@ ERG = Namespace("http://www.delph-in.net/schema/erg#")
 DELPH = Namespace("http://www.delph-in.net/schema/")
 POS = Namespace("http://www.delph-in.net/schema/pos#")
 
-def __nodes_to_rdf__(e, graph, edsi, NODES):
+def __nodes_to_rdf__(e, graph, edsi, NODES, namespace):
     """
     Creates nodes of variables and nodes specifying their properties.
 
@@ -26,11 +26,13 @@ def __nodes_to_rdf__(e, graph, edsi, NODES):
     edsi - The URI of the EDS instance being parsed.
 
     NODES - the URI namespace dedicated to nodes.
+
+    namespace - the string namespace of a result of the profile.
     """
     for node in e.nodes:
         nodeIRI = NODES[node.id]
-        nodePredIRI = NODES[node.id + "-predicate"]
-        nodeSortInfoIRI = NODES[node.id + "-sortinfo"]
+        nodePredIRI = URIRef(f"{namespace}predicate-{node.id}")
+        nodeSortInfoIRI = URIRef(f"{namespace}sortinfo-{node.id}")
         
         #Instantiate the Node
         graph.add((nodeIRI, RDF.type, EDS.Node))
@@ -129,7 +131,7 @@ def eds_to_rdf(e, prefix: str, identifier, iname="eds", graph=None, out=None, te
     #creating the instance URI and the namespace of nodes
     edsi = URIRef(namespace + iname)
     graph.add((edsi, RDF.type, EDS.EDS))
-    NODES = Namespace(namespace + "nodes-")
+    NODES = Namespace(namespace + "node-")
 
     #creating the prefixes of the output
     graph.bind("eds", EDS)
@@ -138,7 +140,7 @@ def eds_to_rdf(e, prefix: str, identifier, iname="eds", graph=None, out=None, te
     graph.bind("pos", POS)
     
     #Creating the RDF triples
-    __nodes_to_rdf__(e, graph, edsi, NODES)
+    __nodes_to_rdf__(e, graph, edsi, NODES, namespace)
     #Adding top
     graph.add((edsi, DELPH['hasTop'], NODES[e.top]))
     __edges_to_rdf__(e, graph, NODES)

--- a/delphin/rdf/_eds_parser.py
+++ b/delphin/rdf/_eds_parser.py
@@ -29,7 +29,7 @@ def __nodes_to_rdf__(e, graph, edsi, NODES):
     """
     for node in e.nodes:
         nodeIRI = NODES[node.id]
-        nodePredIRI = NODES[node.id + "#predicate"]
+        nodePredIRI = NODES[node.id + "-predicate"]
         
         #Instantiate the Node
         graph.add((nodeIRI, RDF.type, EDS.Node))
@@ -92,7 +92,7 @@ def __edges_to_rdf__(e, graph, NODES):
         
 
         
-def eds_to_rdf(e, prefix: str, identifier, iname="edsi#eds", graph=None, out=None, text=None, format="turtle"):
+def eds_to_rdf(e, prefix: str, identifier, iname="eds", graph=None, out=None, text=None, format="turtle"):
     """
     Parses a pydelphin EDS into RDF representation.
 
@@ -107,7 +107,7 @@ def eds_to_rdf(e, prefix: str, identifier, iname="edsi#eds", graph=None, out=Non
     same text admits various eds interpretations.
 
     iname - the eds instance name (the eds as RDF node name)
-    to be used. As default, it is "edsi#eds".
+    to be used. As default, it is "eds".
 
     graph - and rdflib graph. If given, uses it to store the
     mrs as RDF representation.
@@ -122,12 +122,12 @@ def eds_to_rdf(e, prefix: str, identifier, iname="edsi#eds", graph=None, out=Non
     if type(identifier) == list:
         identifier = "/".join(identifier)
     
-    namespace = prefix + "/" + identifier + "/"
+    namespace = prefix + "/" + identifier + "#"
 
     #creating the instance URI and the namespace of nodes
     edsi = URIRef(namespace + iname)
     graph.add((edsi, RDF.type, EDS.EDS))
-    NODES = Namespace(namespace + "nodes/")
+    NODES = Namespace(namespace + "nodes-")
 
     #creating the prefixes of the output
     graph.bind("eds", EDS)

--- a/delphin/rdf/_eds_parser.py
+++ b/delphin/rdf/_eds_parser.py
@@ -30,6 +30,7 @@ def __nodes_to_rdf__(e, graph, edsi, NODES):
     for node in e.nodes:
         nodeIRI = NODES[node.id]
         nodePredIRI = NODES[node.id + "-predicate"]
+        nodeSortInfoIRI = NODES[node.id + "-sortinfo"]
         
         #Instantiate the Node
         graph.add((nodeIRI, RDF.type, EDS.Node))
@@ -68,12 +69,13 @@ def __nodes_to_rdf__(e, graph, edsi, NODES):
             graph.add((nodeIRI, RDF.type, DELPH[node.type]))
         
         # properties
+        graph.add((nodeIRI, DELPH.hasSortInfo, nodeSortInfoIRI))
+        graph.add((nodeSortInfoIRI, RDF.type, DELPH.SortInfo))
         for prop in node.properties.items():
-            graph.add((nodeIRI, ERG[prop[0].lower()], Literal(prop[1].lower())))
-            
+            graph.add((nodeSortInfoIRI, ERG[prop[0].lower()], Literal(prop[1].lower())))
         # carg
         if node.carg:
-            graph.add((nodeIRI, DELPH.carg, Literal(node.carg)))
+            graph.add((nodeSortInfoIRI, DELPH.carg, Literal(node.carg)))
 
 
 def __edges_to_rdf__(e, graph, NODES):

--- a/delphin/rdf/_mrs_parser.py
+++ b/delphin/rdf/_mrs_parser.py
@@ -39,7 +39,7 @@ def _vars_to_rdf(m, graph, VARS):
             # adding the properties of the variables
             for props in v[1].items():
                 graph.add((VARS[v[0]], ERG[props[0].lower()], Literal(props[1])))
-            #maybe it won't be harmful to reassure that the property is defined in ERG, but it'll be like that for now.
+            # it won't be harmful to reassure that the property is defined in ERG, but it'll be like that for now.
         else:
             print("Invalid predicate")
 def _rels_to_rdf(m, graph, mrsi, RELS, VARS):
@@ -58,7 +58,7 @@ def _rels_to_rdf(m, graph, mrsi, RELS, VARS):
     for rel in range(len(m.rels)):
         mrs_rel = m.rels[rel]
         rdf_rel = RELS["EP{rel}".format(rel=rel)] #maybe label EPs in a different manner is better because they aren't ordered.
-        pred_rel = RELS["EP{rel}#predicate".format(rel=rel)] #revise
+        pred_rel = RELS["EP{rel}-predicate".format(rel=rel)]
 
         graph.add((mrsi, MRS.hasEP, rdf_rel))
         graph.add((rdf_rel, RDF.type, MRS.ElementaryPredication))
@@ -164,7 +164,7 @@ def mrs_to_rdf(
         m:delphin.mrs._mrs.MRS,
         prefix:str,
         identifier:Union[str, list],
-        iname:str ="mrsi#mrs",
+        iname:str ="mrs",
         graph:rdflib.graph.Graph=None,
         text:str=None) -> rdflib.graph.Graph:
     """
@@ -191,13 +191,13 @@ def mrs_to_rdf(
         identifier = "/".join(identifier)
 
     # creating the namespaces for this MRS instance
-    namespace = prefix + "/" + identifier + "/"
+    namespace = prefix + "/" + identifier + "#"
     mrsi = URIRef(namespace + iname)
     graph.add((mrsi, RDF.type, MRS.MRS))
-    VARS = Namespace(namespace + "variables/")
-    RELS = Namespace(namespace + "rels/")
-    HCONS = Namespace(namespace + "hcons/")
-    ICONS = Namespace(namespace + "icons/")
+    VARS = Namespace(namespace + "variables-")
+    RELS = Namespace(namespace + "rels-")
+    HCONS = Namespace(namespace + "hcons-")
+    ICONS = Namespace(namespace + "icons-")
     
     # creating the prefixes of the output
     graph.bind("mrs", MRS)

--- a/delphin/rdf/_mrs_parser.py
+++ b/delphin/rdf/_mrs_parser.py
@@ -42,7 +42,7 @@ def _vars_to_rdf(m, graph, VARS):
             # it won't be harmful to reassure that the property is defined in ERG, but it'll be like that for now.
         else:
             print("Invalid predicate")
-def _rels_to_rdf(m, graph, mrsi, RELS, VARS):
+def _rels_to_rdf(m, graph, mrsi, RELS, VARS, namespace):
     """
     Describes EPs "RELS" in an MRS-RDF format
 
@@ -53,13 +53,14 @@ def _rels_to_rdf(m, graph, mrsi, RELS, VARS):
         mrsi: the mrs instance name (the MRS as RDF node name)
         RELS: the URI namespace dedicated to EPs
         VARS: the URI namespace dedicated to variables
+        namespace - the string namespace of a result of the profile.
     """
 
     for rel in range(len(m.rels)):
         mrs_rel = m.rels[rel]
-        rdf_rel = RELS["EP{rel}".format(rel=rel)] #maybe label EPs in a different manner is better because they aren't ordered.
-        pred_rel = RELS["EP{rel}-predicate".format(rel=rel)]
-        sortinfo_rel = RELS["EP{rel}-sortinfo".format(rel=rel)]
+        rdf_rel = RELS["{rel}".format(rel=rel)] #maybe label EPs in a different manner is better because they aren't ordered.
+        pred_rel = URIRef(f"{namespace}predicate-{rel}")
+        sortinfo_rel = URIRef(f"{namespace}sortinfo-{rel}")
 
         graph.add((mrsi, MRS.hasEP, rdf_rel))
         graph.add((rdf_rel, RDF.type, MRS.ElementaryPredication))
@@ -197,7 +198,7 @@ def mrs_to_rdf(
     mrsi = URIRef(namespace + iname)
     graph.add((mrsi, RDF.type, MRS.MRS))
     VARS = Namespace(namespace + "variables-")
-    RELS = Namespace(namespace + "rels-")
+    RELS = Namespace(namespace + "EP-")
     HCONS = Namespace(namespace + "hcons-")
     ICONS = Namespace(namespace + "icons-")
     
@@ -209,7 +210,7 @@ def mrs_to_rdf(
     
     # creating the RDF triples
     _vars_to_rdf(m, graph, VARS)
-    _rels_to_rdf(m, graph, mrsi, RELS, VARS)
+    _rels_to_rdf(m, graph, mrsi, RELS, VARS, namespace)
     _hcons_to_rdf(m, graph, mrsi, HCONS, VARS)
     _icons_to_rdf(m, graph, mrsi, ICONS, VARS)
     # adding top

--- a/delphin/rdf/_mrs_parser.py
+++ b/delphin/rdf/_mrs_parser.py
@@ -59,6 +59,7 @@ def _rels_to_rdf(m, graph, mrsi, RELS, VARS):
         mrs_rel = m.rels[rel]
         rdf_rel = RELS["EP{rel}".format(rel=rel)] #maybe label EPs in a different manner is better because they aren't ordered.
         pred_rel = RELS["EP{rel}-predicate".format(rel=rel)]
+        sortinfo_rel = RELS["EP{rel}-sortinfo".format(rel=rel)]
 
         graph.add((mrsi, MRS.hasEP, rdf_rel))
         graph.add((rdf_rel, RDF.type, MRS.ElementaryPredication))
@@ -92,7 +93,8 @@ def _rels_to_rdf(m, graph, mrsi, RELS, VARS):
             graph.add((rdf_rel, DELPH.cto, Literal(mrs_rel.cto))) #integer
      
         # parse arguments
-        
+        graph.add((rdf_rel, DELPH.hasSortInfo, sortinfo_rel))
+        graph.add((sortinfo_rel, RDF.type, DELPH.SortInfo))
         for hole, arg in mrs_rel.args.items():
             #if hole == "ARG0": continue
             # arg_type = type(eval(arg.title()))
@@ -100,9 +102,9 @@ def _rels_to_rdf(m, graph, mrsi, RELS, VARS):
             
             # mrs variables as arguments
             if hole.lower() != "carg" :
-                graph.add((rdf_rel, MRS[hole.lower()], VARS[arg]))
+                graph.add((sortinfo_rel, MRS[hole.lower()], VARS[arg]))
             else :
-                graph.add((rdf_rel, DELPH.carg, Literal(arg)))
+                graph.add((sortinfo_rel, DELPH.carg, Literal(arg)))
                 
 
 def _hcons_to_rdf(m, graph, mrsi, HCONS, VARS):

--- a/vocabularies/erg.ttl
+++ b/vocabularies/erg.ttl
@@ -39,8 +39,8 @@ erg:ind
 
 erg:pt
  a rdf:Property ;
- rdfs:subPropertyOf delph:x ;
- rdfs:domain delph:Identifier ;
+ rdfs:subPropertyOf delph:hasPropertyValue ;
+ rdfs:domain delph:x ;
  rdfs:range rdfs:Literal ;
  rdfs:comment "A property that states the pronoum type"@en-us.
 

--- a/vocabularies/semstructs.ttl
+++ b/vocabularies/semstructs.ttl
@@ -41,6 +41,10 @@ delph:AbstractPredicate
  rdfs:subClassOf delph:Predicate;
  rdfs:comment "The class of the semantic predicates that represents the overt words in a sentence"@en-us .
 
+delph:SortInfo
+ a rdfs:Class ;
+ rdfs:comment "The class for nodes which represents the morphosemantic information of a predication"@en-us .
+
 delph:Pos
  a rdf:Class ;
  
@@ -99,6 +103,12 @@ delph:hasPredication
  rdfs:range delph:Predication ;
  rdfs:comment "A property that links a semantic structure to one of its predications"@en-us.
 
+delph:hasSortInfo
+ a rdf:Property ;
+ rdfs:domain delph:Predication ;
+ rdfs:range delph:SortInfo ;
+ rdfs:comment "A property that links a predication to its information"@en-us.
+
 delph:hasPredicate
  a rdf:Property ;
  rdfs:domain delph:Predication ;
@@ -144,7 +154,7 @@ delph:cto
 
 delph:hasPropertyValue
  a rdf:Property ;
- rdfs:domain delph:Identifier ;
+ rdfs:domain delph:SortInfo ;
  rdfs:range rdfs:Literal ;
  rdfs:comment "A general property to link an identifier to a morphosemantic property value"@en-us.
 

--- a/vocabularies/semstructs.ttl
+++ b/vocabularies/semstructs.ttl
@@ -156,7 +156,7 @@ delph:hasPropertyValue
  a rdf:Property ;
  rdfs:domain delph:SortInfo ;
  rdfs:range rdfs:Literal ;
- rdfs:comment "A general property to link an SortInfo node to the morphosemantic property value"@en-us.
+ rdfs:comment "A general property to link an SortInfo node to a morphosemantic property value"@en-us.
 
 delph:text
  a rdf:Property ;

--- a/vocabularies/semstructs.ttl
+++ b/vocabularies/semstructs.ttl
@@ -156,7 +156,7 @@ delph:hasPropertyValue
  a rdf:Property ;
  rdfs:domain delph:SortInfo ;
  rdfs:range rdfs:Literal ;
- rdfs:comment "A general property to link an identifier to a morphosemantic property value"@en-us.
+ rdfs:comment "A general property to link an SortInfo node to the morphosemantic property value"@en-us.
 
 delph:text
  a rdf:Property ;


### PR DESCRIPTION
This PR solves #23 creating the notion of "sort info" across all semantic representations. It represents the morphosemantic information that is extracted when analyzing a sentence. It also tackles the naming problem in #21. Now, the it exchanged

1.  http://ibm.com/sick/b/33/4/dmrsi#dmrs to http://ibm.com/sick/b/result-33-4#mrs
2. http://ibm.com/sick/b/33/4/nodes/10012 to http://ibm.com/sick/b/33/4#node-10012
3. http://ibm.com/sick/b/33/4/links/8 to http://ibm.com/sick/b/33/4#link-8 
4. http://ibm.com/sick/b/33/4/nodes/10014#predicate to http://ibm.com/sick/b/33/4#node-10012-predicate

Of the three semantic representations right now, only two of them have XML serialization. [DMRS DTD](http://svn.emmtee.net/trunk/lingo/lkb/src/rmrs/dmrs.dtd) calls this information of "sortinfo", but [MRS DTD](svn.emmtee.net/trunk/lingo/lkb/src/mrs/mrs.dtd) (which is referenced [here](http://moin.delph-in.net/wiki/MrsRfc) with a newer description of the XML serialization of MRSs which include ICONS) treat this as "extra pairs". The name of the resource can be changed later or specific names can be put in each representation.

This PR also puts more info on the first level of verbosity, addressing #17. Right now, we have
```bash
$ delphin profile-to-rdf -v --to dmrs ../erg/trunk/tsdb/gold/mrs/
WARNING:delphin.cli.profile_to_rdf:Converting 107 analysis of 107 sentences from ../erg/trunk/tsdb/gold/mrs/
WARNING:delphin.cli.profile_to_rdf:Loading the profile
WARNING:delphin.cli.profile_to_rdf:Converting the profile
WARNING:delphin.cli.profile_to_rdf:Result 0 of sentence 951 is not well formed
WARNING:delphin.cli.profile_to_rdf:Serializing results to output.ttl
WARNING:delphin.cli.profile_to_rdf:DONE
```
The name of the log message (`WARNING`) shall be changed later.